### PR TITLE
update to writeFileSync to avoid race condition when opening report

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var DHTMLReporter = function (logger, config, basePath) {
         }
         var outFile=basePath+options.outputFile;
         console.log('DHTML report wrote to ' + outFile);
-        fs.writeFile(outFile, jade.renderFile(__dirname+'/themes/default/index.jade', {
+        fs.writeFileSync(outFile, jade.renderFile(__dirname+'/themes/default/index.jade', {
             summary: result,
             data   : browsers,
             config : options,


### PR DESCRIPTION
On Linux using node 6.1 I sometimes get an ENOENT error when attempting to open the report right after the tests are run, this fixes it by writing the file synchronously.
